### PR TITLE
Fix for lab3 guide

### DIFF
--- a/lab-guide/Lab-3-Logging-legacy.md
+++ b/lab-guide/Lab-3-Logging-legacy.md
@@ -114,7 +114,7 @@ $ gradle check
 файловый ввод-вывод.
 
   1. Первым делом создаем папку `Infrastructure` и в ней директории для
-     исходников `src/main` и `src/test`. Далее пишем `build.gradle` файл и
+     исходников `src/main/java` и `src/test/java`. Далее пишем `build.gradle` файл и
      регистрируем его в общем `settings.gradle`, подобно тому как это делалось
      в прошлой лабораторной работе. Нужно будет снова запустить команду
      `gradle idea` для генерации проекта. Ниже пример файла `build.gradle`:
@@ -125,8 +125,8 @@ dependencies {
 }
 
 sourceSets {
-    main.java.srcDir 'src/main'
-    test.java.srcDir 'src/test'
+    main.java.srcDir 'src/main/java'
+    test.java.srcDir 'src/test/java'
 }
 ```
   1. Когда окружение готово, можно приступать к реализации класса-логгера.


### PR DESCRIPTION
Added "java" folder to the build.gradle file.
I got the the Travis error with build.gradle from old description lab3.
Travis said that I have copied the code from myself.
https://travis-ci.org/UNN-VMK-Software/agile-course-practice/builds/45060092
for example:
Copy-paste rate: 2 times
[***************\* Found in: ****************]
/home/travis/build/UNN-VMK-Software/agile-course-practice/code/Ljaljushkin-Nikolay/Infrastructure/src/main/java/ru/unn/agile/ColorConverter/infrastructure/DatedTextLogger.java, started @9 line
/home/travis/build/UNN-VMK-Software/agile-course-practice/code/Ljaljushkin-Nikolay/Infrastructure/src/main/java/ru/unn/agile/ColorConverter/infrastructure/DatedTextLogger.java, started @9 line
